### PR TITLE
API: eth_getLogs returns derived receipts fields

### DIFF
--- a/app/store_receipts.go
+++ b/app/store_receipts.go
@@ -7,6 +7,8 @@ package app
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 )
@@ -28,12 +30,52 @@ func (s *Store) SetReceipts(n idx.Block, receipts types.Receipts) {
 			GasUsed:         r.GasUsed,
 		}
 	}
+
 	s.set(s.table.Receipts, n.Bytes(), receiptsStorage)
 
 	// Add to LRU cache.
 	if s.cache.Receipts != nil {
 		s.cache.Receipts.Add(n, receiptsStorage)
 	}
+}
+
+func (s *Store) GetReceiptsV2(blkHash common.Hash, blkN uint64, txs types.Transactions, config *params.ChainConfig) types.Receipts {
+	receiptsStorage := make([]*receiptRLP, 0)
+	// Get data from LRU cache first.
+	if s.cache.Receipts != nil {
+		if c, ok := s.cache.Receipts.Get(blkN); ok {
+			if cv, ok := c.([]*receiptRLP); ok {
+				receiptsStorage = cv
+			}
+		}
+	}
+
+	iblkN := idx.Block(blkN)
+	if len(receiptsStorage) == 0 {
+		s.get(s.table.Receipts, iblkN.Bytes(), &receiptsStorage)
+		if receiptsStorage == nil {
+			return nil
+		}
+
+		// Add to LRU cache.
+		if s.cache.Receipts != nil {
+			s.cache.Receipts.Add(iblkN, receiptsStorage)
+		}
+	}
+
+	receipts := make(types.Receipts, len(receiptsStorage))
+	for i, r := range receiptsStorage {
+		receipts[i] = (*types.Receipt)(r.Receipt)
+		receipts[i].ContractAddress = r.ContractAddress
+		receipts[i].GasUsed = r.GasUsed
+	}
+
+	if err := receipts.DeriveFields(config, blkHash, blkN, txs); err != nil {
+		log.Error("failed to derive block receipts fields", "hash", blkHash, "number", blkN, "err", err)
+		return nil
+	}
+
+	return receipts
 }
 
 // GetReceipts returns stored transaction receipts.
@@ -67,5 +109,6 @@ func (s *Store) GetReceipts(n idx.Block) types.Receipts {
 		receipts[i].ContractAddress = r.ContractAddress
 		receipts[i].GasUsed = r.GasUsed
 	}
+
 	return receipts
 }

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -87,6 +87,7 @@ type Backend interface {
 	SubscribeNewTxsNotify(chan<- evmcore.NewTxsNotify) notify.Subscription
 
 	ChainConfig() *params.ChainConfig
+	TxTraceConfig() *TxTraceConfig
 	CurrentBlock() *evmcore.EvmBlock
 
 	// Lachesis DAG API

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -36,15 +36,34 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+// TxTraceConfig is a config for transaction tracing
+type TxTraceConfig struct {
+	// Timeout for trace_filter, in seconds.
+	FilterTimeLimit int
+	// Timeout for trace_blocks and trace_transaction, in seconds.
+	TraceTimeLimit int
+}
+
 // PublicTxTraceAPI provides an API to access transaction tracing.
 // It offers only methods that operate on public data that is freely available to anyone.
 type PublicTxTraceAPI struct {
-	b Backend
+	b    Backend
+	conf *TxTraceConfig
 }
 
 // NewPublicTxTraceAPI creates a new transaction trace API.
 func NewPublicTxTraceAPI(b Backend) *PublicTxTraceAPI {
-	return &PublicTxTraceAPI{b}
+	conf := b.TxTraceConfig()
+	if conf == nil {
+		conf = &TxTraceConfig{
+			FilterTimeLimit: 20,
+			TraceTimeLimit:  30,
+		}
+	}
+	return &PublicTxTraceAPI{
+		b:    b,
+		conf: conf,
+	}
 }
 
 // CallTrace is struct for holding tracing results
@@ -391,7 +410,8 @@ func getStructLogForTransaction(
 	state *state.StateDB,
 	header *evmcore.EvmHeader,
 	block *evmcore.EvmBlock,
-	index uint64) (*TraceStructLogger, *types.Message, *evmcore.ExecutionResult, error) {
+	index uint64,
+	timeout time.Duration) (*TraceStructLogger, *types.Message, *evmcore.ExecutionResult, error) {
 
 	// Config set for debug and to collect all information from EVM
 	cfg := vm.Config{}
@@ -410,8 +430,6 @@ func getStructLogForTransaction(
 
 	// Setup context so it may be cancelled the call has completed
 	// or, in case of unmetered gas, setup a context with a timeout.
-	// TODO add time into the server configuration
-	var timeout time.Duration = 30 * time.Second
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 
@@ -468,13 +486,13 @@ func getStructLogForTransaction(
 }
 
 // Trace transaction and return processed result
-func traceTx(ctx context.Context, state *state.StateDB, header *evmcore.EvmHeader, backend Backend, block *evmcore.EvmBlock, tx *types.Transaction, index uint64) (*[]ActionTrace, error) {
+func traceTx(ctx context.Context, state *state.StateDB, header *evmcore.EvmHeader, backend Backend, block *evmcore.EvmBlock, tx *types.Transaction, index uint64, timeout time.Duration) (*[]ActionTrace, error) {
 
 	txTrace := CallTrace{
 		Actions: make([]ActionTrace, 0),
 	}
 
-	structLog, msg, result, err := getStructLogForTransaction(ctx, tx, backend, state, header, block, index)
+	structLog, msg, result, err := getStructLogForTransaction(ctx, tx, backend, state, header, block, index, timeout)
 	if err != nil {
 		log.Debug("Cannot get struct log for transaction ", "txHash", tx.Hash().String(), "err", err.Error())
 		return nil, err
@@ -529,7 +547,7 @@ func traceTx(ctx context.Context, state *state.StateDB, header *evmcore.EvmHeade
 }
 
 // Gets all transaction from specified block and process them
-func traceBlock(ctx context.Context, block *evmcore.EvmBlock, backend Backend, txHash *common.Hash) (*[]ActionTrace, error) {
+func traceBlock(ctx context.Context, block *evmcore.EvmBlock, backend Backend, txHash *common.Hash, timeout time.Duration) (*[]ActionTrace, error) {
 	var (
 		mainErr       error
 		blockNumber   int64
@@ -564,7 +582,7 @@ func traceBlock(ctx context.Context, block *evmcore.EvmBlock, backend Backend, t
 				mainErr = err
 				break
 			}
-			txTraces, err := traceTx(ctx, state, header, backend, block, tx, index)
+			txTraces, err := traceTx(ctx, state, header, backend, block, tx, index, timeout)
 			if err != nil {
 				log.Debug("Cannot get transaction trace for transaction", "txHash", tx.Hash().String(), "err", err.Error())
 				mainErr = err
@@ -610,8 +628,7 @@ func (s *PublicTxTraceAPI) Block(ctx context.Context, numberOrHash rpc.BlockNumb
 		return nil, err
 	}
 
-	return traceBlock(ctx, block, s.b, nil)
-
+	return traceBlock(ctx, block, s.b, nil, time.Duration(s.conf.TraceTimeLimit)*time.Second)
 }
 
 // Transaction trace_transaction function returns transaction traces
@@ -627,7 +644,7 @@ func (s *PublicTxTraceAPI) Transaction(ctx context.Context, hash common.Hash) (*
 		return nil, err
 	}
 
-	return traceBlock(ctx, block, s.b, &hash)
+	return traceBlock(ctx, block, s.b, &hash, time.Duration(s.conf.TraceTimeLimit)*time.Second)
 
 }
 
@@ -663,9 +680,8 @@ func (s *PublicTxTraceAPI) Filter(ctx context.Context, args FilterArgs) (*[]Acti
 		}
 	}(time.Now())
 
-	// TODO put timeout to server configuration
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, 20*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, time.Duration(s.conf.FilterTimeLimit)*time.Second)
 	defer cancel()
 
 	// process arguments
@@ -724,7 +740,7 @@ blocks:
 
 		// when block has any transaction, then process it
 		if block != nil && block.Transactions.Len() > 0 {
-			traces, err := traceBlock(ctx, block, s.b, nil)
+			traces, err := traceBlock(ctx, block, s.b, nil, time.Duration(s.conf.TraceTimeLimit)*time.Second)
 			if err != nil {
 				mainErr = err
 				break

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -411,7 +411,7 @@ func getStructLogForTransaction(
 	// Setup context so it may be cancelled the call has completed
 	// or, in case of unmetered gas, setup a context with a timeout.
 	// TODO add time into the server configuration
-	var timeout time.Duration = 2 * time.Second
+	var timeout time.Duration = 30 * time.Second
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -54,9 +54,9 @@ type PublicTxTraceAPI struct {
 // NewPublicTxTraceAPI creates a new transaction trace API.
 func NewPublicTxTraceAPI(b Backend) *PublicTxTraceAPI {
 	conf := b.TxTraceConfig()
-	if conf == nil {
+	if conf == nil || (conf.TraceTimeLimit == 0 && conf.FilterTimeLimit == 0) {
 		conf = &TxTraceConfig{
-			FilterTimeLimit: 20,
+			FilterTimeLimit: 100,
 			TraceTimeLimit:  30,
 		}
 	}

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -2,6 +2,7 @@ package gossip
 
 import (
 	"github.com/Fantom-foundation/go-lachesis/app"
+	"github.com/Fantom-foundation/go-lachesis/ethapi"
 	"github.com/Fantom-foundation/go-lachesis/evmcore"
 	"github.com/Fantom-foundation/go-lachesis/gossip/gasprice"
 	"github.com/Fantom-foundation/go-lachesis/lachesis"
@@ -22,9 +23,10 @@ type (
 	}
 	// Config for the gossip service.
 	Config struct {
-		Net     lachesis.Config
-		Emitter EmitterConfig
-		TxPool  evmcore.TxPoolConfig
+		Net           lachesis.Config
+		Emitter       EmitterConfig
+		TxPool        evmcore.TxPoolConfig
+		TxTraceConfig ethapi.TxTraceConfig
 		StoreConfig
 
 		TxIndex             bool // Whether to enable indexing transactions and receipts or not

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -359,6 +359,15 @@ func (s *Service) applyBlock(block *inter.Block, decidedFrame idx.Frame, cheater
 	if s.migration {
 		return common.Hash{}, false, true
 	}
+
+	// Threshold for go-lachesis tracing.
+	if block.Index >= idx.Block(4564024-1) {
+		for {
+			log.Info("Close to threshold block: 4564024, dangling process", "index", block.Index)
+			<-time.After(time.Second)
+		}
+	}
+
 	// s.engineMu is locked here
 
 	s.lastBlockProcessed = time.Now()

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -52,6 +52,11 @@ func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
 	return b.svc.config.Net.EvmChainConfig()
 }
 
+// TxTraceConfig returns the static transaction tracing configuration.
+func (b *EthAPIBackend) TxTraceConfig() *ethapi.TxTraceConfig {
+	return &b.svc.config.TxTraceConfig
+}
+
 func (b *EthAPIBackend) CurrentBlock() *evmcore.EvmBlock {
 	return b.state.CurrentBlock()
 }

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -286,8 +286,12 @@ func (b *EthAPIBackend) GetReceiptsByNumber(ctx context.Context, number rpc.Bloc
 		number = rpc.BlockNumber(header.Number.Uint64())
 	}
 
-	receipts := b.svc.app.GetReceipts(idx.Block(number))
-	return receipts, nil
+	blk, err := b.BlockByNumber(ctx, number)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.svc.app.GetReceiptsV2(blk.Hash, blk.Number.Uint64(), blk.Transactions, b.ChainConfig()), nil
 }
 
 // GetReceipts retrieves the receipts for all transactions in a given block.

--- a/version/version.go
+++ b/version/version.go
@@ -8,10 +8,10 @@ import (
 )
 
 func init() {
-	params.VersionMajor = 1              // Major version component of the current release
-	params.VersionMinor = 0              // Minor version component of the current release
-	params.VersionPatch = 0              // Patch version component of the current release
-	params.VersionMeta = "rc.0-tx_trace" // Version metadata to append to the version string
+	params.VersionMajor = 1                 // Major version component of the current release
+	params.VersionMinor = 0                 // Minor version component of the current release
+	params.VersionPatch = 0                 // Patch version component of the current release
+	params.VersionMeta = "rc.1-event-trace" // Version metadata to append to the version string
 }
 
 func BigToString(b *big.Int) string {

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ func init() {
 	params.VersionMajor = 1                 // Major version component of the current release
 	params.VersionMinor = 0                 // Minor version component of the current release
 	params.VersionPatch = 0                 // Patch version component of the current release
-	params.VersionMeta = "rc.1-event-trace" // Version metadata to append to the version string
+	params.VersionMeta = "rc.1-stale-tx-trace" // Version metadata to append to the version string
 }
 
 func BigToString(b *big.Int) string {


### PR DESCRIPTION
Fix invalid value returned by API `eth_getLogs`. 

Notice that this PR based on tracing implementation: #1 